### PR TITLE
Fix ropasaurus to use included script; make baby work the same way

### DIFF
--- a/babys-first-rop-32/Dockerfile
+++ b/babys-first-rop-32/Dockerfile
@@ -6,4 +6,4 @@ RUN chmod +x challenge
 WORKDIR /challenge
 
 EXPOSE 31337
-CMD ["/usr/sbin/xinetd", "-d", "-dontfork", "-f", "challenge.conf"]
+CMD ["/bin/bash", "run_xinetd.sh"]

--- a/babys-first-rop-32/contents/run_xinetd.sh
+++ b/babys-first-rop-32/contents/run_xinetd.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+# Adapted from: https://rimuhosting.com/knowledgebase/linux/misc/trapping-ctrl-c-in-bash
+
+cd /challenge
+
+# trap ctrl-c and call ctrl_c()
+trap ctrl_c INT
+
+function ctrl_c() {
+	kill -9 $APP_PID
+}
+
+/usr/sbin/xinetd -dontfork -f challenge.conf & export APP_PID=$!
+echo "Running succesfully, go forth and hack!"
+wait $APP_PID
+

--- a/ropasaurusrex/Dockerfile
+++ b/ropasaurusrex/Dockerfile
@@ -6,4 +6,4 @@ RUN chmod +x challenge
 WORKDIR /challenge
 
 EXPOSE 31337
-CMD ["/usr/sbin/xinetd", "-d", "-dontfork", "-f", "challenge.conf"]
+CMD ["/bin/bash", "run_xinetd.sh"]


### PR DESCRIPTION
This way these two can run as daemons (I assume the others are the same way, but I only tested these)